### PR TITLE
Adapt to iOS 14 tracking transparency API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@
 
 - [Supported Platforms](#supported-platforms)
 - [Installation](#installation)
-- [Methods](#methods)
+- [API](#api)
+- [Example](#example)
 
 <!-- /MarkdownTOC -->
 
 ## Supported Platforms
 
-- iOS
+- iOS (Xcode 12+)
 - Android
 
 ## Installation
@@ -26,11 +27,23 @@
 
 Use variable `PLAY_SERVICES_ADS_VERSION` to override dependency version on Android.
 
-## Methods
-Every method returns a promise that fulfills when a call was successful.
+## API
+
+The API is available on the `cordova.plugins.idfa` global object.
 
 ### getInfo()
-Returns advertising id with `limitAdTracking` flag. On iOS use `idfa` property, on Android use `aaid`.
+
+Returns a `Promise<object>` with the following fields:
+
+- `limitAdTracking`: `boolean` - Whether usage of advertising id is allowed by user.
+- `idfa`: `string` - Identifier for advertisers (_iOS only_).
+- `trackingTransparencyStatus`: `"NotAvailable"` | `"Authorized"` | `"Denied"` | `"Restricted"` | `"NotDetermined"` -
+   Tracking transparency status, available on iOS 14+ devices. On devices with iOS < 14 the value will always be
+   `"NotAvailable"`. For the meaning of other values see [the tracking transparency API docs][tracking-transparency-api].
+- `aaid`: `string` - Android advertising ID (_Android only_).
+
+## Example
+
 ```js
 cordova.plugins.idfa.getInfo().then(function(info) {
     if (!info.limitAdTracking) {
@@ -38,9 +51,11 @@ cordova.plugins.idfa.getInfo().then(function(info) {
     }
 });
 ```
+
 [npm-url]: https://www.npmjs.com/package/cordova-plugin-idfa
 [npm-version]: https://img.shields.io/npm/v/cordova-plugin-idfa.svg
 [npm-downloads]: https://img.shields.io/npm/dm/cordova-plugin-idfa.svg
 [twitter-url]: https://twitter.com/chemerisuk
 [twitter-follow]: https://img.shields.io/twitter/follow/chemerisuk.svg?style=social&label=Follow%20me
 [donate-url]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=E62XVSR3XUGDE&source=url
+[tracking-transparency-api]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ The API is available on the `cordova.plugins.idfa` global object.
 Returns a `Promise<object>` with the following fields:
 
 - `limitAdTracking`: `boolean` - Whether usage of advertising id is allowed by user.
-- `idfa`: `string` - Identifier for advertisers (_iOS only_).
-- `trackingTransparencyStatus`: `"NotAvailable"` | `"Authorized"` | `"Denied"` | `"Restricted"` | `"NotDetermined"` -
+- `idfa`: `string` (_iOS only_) - Identifier for advertisers.
+- `trackingTransparencyStatus` (_iOS only_): `"NotAvailable"` | `"Authorized"` | `"Denied"` | `"Restricted"` | `"NotDetermined"` -
    Tracking transparency status, available on iOS 14+ devices. On devices with iOS < 14 the value will always be
    `"NotAvailable"`. For the meaning of other values see [the tracking transparency API docs][tracking-transparency-api].
-- `aaid`: `string` - Android advertising ID (_Android only_).
+- `aaid`: `string` (_Android only_) - Android advertising ID.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Supported Platforms
 
-- iOS (Xcode 12+)
+- iOS
 - Android
 
 ## Installation

--- a/plugin.xml
+++ b/plugin.xml
@@ -31,6 +31,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/IdfaPlugin.m" />
 
         <framework src="AdSupport.framework" weak="true" />
+        <framework src="AppTrackingTransparency.framework" weak="true" />
     </platform>
 
     <platform name="android">

--- a/src/ios/IdfaPlugin.m
+++ b/src/ios/IdfaPlugin.m
@@ -1,5 +1,6 @@
 #import "IdfaPlugin.h"
 #import <AdSupport/ASIdentifierManager.h>
+#import <AppTrackingTransparency/AppTrackingTransparency.h>
 
 @implementation IdfaPlugin
 
@@ -7,10 +8,40 @@
     [self.commandDelegate runInBackground:^{
         NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
         BOOL enabled = [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled];
+        NSString *trackingTransparencyStatus = @"NotAvailable";
+
+        if (@available(iOS 14, *)) {
+            ATTrackingManagerAuthorizationStatus status = ATTrackingManager.trackingAuthorizationStatus;
+            switch (status) {
+                case ATTrackingManagerAuthorizationStatusAuthorized:
+                    trackingTransparencyStatus = @"Authorized";
+                    enabled = YES;
+                    break;
+
+                case ATTrackingManagerAuthorizationStatusDenied:
+                    trackingTransparencyStatus = @"Denied";
+                    break;
+
+                case ATTrackingManagerAuthorizationStatusRestricted:
+                    trackingTransparencyStatus = @"Restricted";
+                    break;
+
+                default:
+                    trackingTransparencyStatus = @"NotDetermined";
+                    break;
+            }
+
+            // workaround, as long as Apple deferred the roll-out of manadatory tracking permission popup
+            // we'll assume that if the idfa string is not nullish, then it's allowed by user
+            if (!enabled && idfaString != nil && ![@"00000000-0000-0000-0000-000000000000" isEqualToString:idfaString]) {
+                enabled = YES;
+            }
+        }
 
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:@{
             @"idfa": idfaString,
-            @"limitAdTracking": [NSNumber numberWithBool:!enabled]
+            @"limitAdTracking": [NSNumber numberWithBool:!enabled],
+            @"trackingTransparencyStatus": trackingTransparencyStatus
         }];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];

--- a/www/Idfa.js
+++ b/www/Idfa.js
@@ -2,9 +2,9 @@ var exec = require("cordova/exec");
 var PLUGIN_NAME = "Idfa";
 
 module.exports = {
-    getInfo: function () {
-        return new Promise(function (resolve, reject) {
+    getInfo: function() {
+        return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "getInfo", []);
         });
-    },
+    }
 };

--- a/www/Idfa.js
+++ b/www/Idfa.js
@@ -5,10 +5,6 @@ module.exports = {
     getInfo: function () {
         return new Promise(function (resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "getInfo", []);
-        }).then(function (obj) {
-            obj.trackingTransparencyStatus =
-                obj.trackingTransparencyStatus || "NotAvailable";
-            return obj;
         });
     },
 };

--- a/www/Idfa.js
+++ b/www/Idfa.js
@@ -2,9 +2,13 @@ var exec = require("cordova/exec");
 var PLUGIN_NAME = "Idfa";
 
 module.exports = {
-    getInfo: function() {
-        return new Promise(function(resolve, reject) {
+    getInfo: function () {
+        return new Promise(function (resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "getInfo", []);
+        }).then(function (obj) {
+            obj.trackingTransparencyStatus =
+                obj.trackingTransparencyStatus || "NotAvailable";
+            return obj;
         });
-    }
+    },
 };


### PR DESCRIPTION
- calculate the value of `limitAdTracking` based on the TTAPI status value (which is always `false` on iOS 14)
- expose the tracking transparency status to JS
- extend API docs to describe the new fields and values