### PR TITLE
Add requestTrackingAuthorization() API to request user's tracking consent on iOS 14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tracking the user or the device. See [Apple's API docs][requesttrackingauthoriza
 for more info on the dialog presented to the user. Available only for iOS 14+ devices.
 
 Returns a `Promise<`[`number`](#tracking-permission-values)`>`. On devices
-with iOS < 14 the promise will always resolve with `null`.
+with iOS < 14 the method will return a rejected promise.
 
 **Note:** You should make sure to set the
 [`NSUserTrackingUsageDescription`][nsusertrackingusagedescription-api-url] key in your app's
@@ -88,13 +88,11 @@ idfaPlugin.getInfo()
             return info.idfa || info.aaid;
         } else if (info.trackingPermission === idfaPlugin.TRACKING_PERMISSION_NOT_DETERMINED) {
             return idfaPlugin.requestPermission().then(result => {
-                if (result !== idfaPlugin.TRACKING_PERMISSION_AUTHORIZED) {
-                    return;
+                if (result === idfaPlugin.TRACKING_PERMISSION_AUTHORIZED) {
+                    return idfaPlugin.getInfo().then(info => {
+                        return info.idfa || info.aaid;
+                    });
                 }
-
-                return idfaPlugin.getInfo().then(info => {
-                    return info.idfa || info.aaid;
-                });
             });
         }
     })

--- a/README.md
+++ b/README.md
@@ -36,8 +36,28 @@ Returns a `Promise<object>` with the following fields:
 - `idfa`: `string` (_iOS only_) - Identifier for advertisers.
 - `trackingTransparencyStatus` (_iOS only_): `"NotAvailable"` | `"Authorized"` | `"Denied"` | `"Restricted"` | `"NotDetermined"` -
    Tracking transparency status, available on iOS 14+ devices. On devices with iOS < 14 the value will always be
-   `"NotAvailable"`. For the meaning of other values see [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
+   `"NotAvailable"`. For the meaning of other values see [the tracking transparency API docs][authorizationstatus-api-url].
 - `aaid`: `string` (_Android only_) - Android advertising ID.
+
+### requestTrackingAuthorization()
+
+_(iOS only)_ A one-time request to authorize or deny access to app-related data that can be used for
+tracking the user or the device. See [Apple's API docs][requesttrackingauthorization-api-url]
+for more info on the dialog presented to the user. Available only for iOS 14+ devices.
+
+Returns a `Promise<string>` with the same values as [`getInfo()#trackingTransparencyStatus`](#getinfo) field.
+On devices with iOS < 14 the promise will always resolve with `"NotAvailable"`.
+
+**Note:** You should make sure to set the `NSUserTrackingUsageDescription` key in your app's
+Information Property List file. You can do it with the following code in your Cordova project's `config.xml`:
+```xml
+<platform name="ios">
+    <edit-config target="NSUserTrackingUsageDescription" file="*-Info.plist" mode="merge">
+        <string>My tracking usage description</string>
+    </edit-config>
+</platform>
+```
+See [Apple's API docs][nsusertrackingusagedescription-api-url] for more info on this configuration key.
 
 ## Example
 
@@ -46,6 +66,10 @@ cordova.plugins.idfa.getInfo().then(function(info) {
     if (!info.limitAdTracking) {
         console.log(info.idfa || info.aaid);
     }
+});
+
+cordova.plugins.idfa.requestTrackingAuthorization().then(function(status) {
+    console.log(status);
 });
 ```
 
@@ -56,3 +80,6 @@ cordova.plugins.idfa.getInfo().then(function(info) {
 [twitter-url]: https://twitter.com/chemerisuk
 [twitter-follow]: https://img.shields.io/twitter/follow/chemerisuk.svg?style=social&label=Follow%20me
 [donate-url]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=E62XVSR3XUGDE&source=url
+[authorizationstatus-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus
+[requesttrackingauthorization-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorization
+[nsusertrackingusagedescription-api-url]: https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The API is available on the `cordova.plugins.idfa` global object.
 
 Returns a `Promise<object>` with the following fields:
 
-- `isTrackingLimited`: `boolean` - Whether usage of advertising id is allowed by user.
+- `trackingLimited`: `boolean` - Whether usage of advertising id is allowed by user.
 - `idfa`: `string` (_iOS only_) - Identifier for advertisers.
-- `trackingPermission` (_iOS only_): [`TrackingPermission`](#trackingpermission)
+- `trackingPermission` (_iOS only_): [`number`](#tracking-permission-values)
    Tracking permission status, available on iOS 14+ devices. On devices with iOS < 14 the value will
    always be `null`.
 - `aaid`: `string` (_Android only_) - Android advertising ID.
@@ -47,7 +47,7 @@ _(iOS only)_ A one-time request to authorize or deny access to app-related data 
 tracking the user or the device. See [Apple's API docs][requesttrackingauthorization-api-url]
 for more info on the dialog presented to the user. Available only for iOS 14+ devices.
 
-Returns a `Promise<`[`TrackingPermission`](#trackingpermission)`>`. On devices
+Returns a `Promise<`[`number`](#tracking-permission-values)`>`. On devices
 with iOS < 14 the promise will always resolve with `null`.
 
 **Note:** You should make sure to set the
@@ -62,31 +62,33 @@ You can do it with the following code in your Cordova project's `config.xml`:
 </platform>
 ```
 
-### TrackingPermission
+### Tracking Permission Values
 
-An `object` containing all possible tracking permission values returned by [`getInfo()#trackingPermission`](#getinfo)
-and [`requestPermission()`](#requestPermission).
+The tracking permission values are `number`s returned by [`getInfo()#trackingPermission`](#getinfo)
+and [`requestPermission()`](#requestPermission). The possible values are stored in constants on the
+plugin object. See the [example](#example) on how to use them.
 
 For the meaning of the values see [the tracking transparency API docs][authorizationstatus-api-url]:
 
-- `Authorized`: `'Authorized'`
-- `Denied`: `'Denied'`
-- `Restricted`: `'Restricted'`
-- `NotDetermined`: `'NotDetermined'`
+| Constant                           | Value | Description                                                                                               |
+| :--------------------------------- | :---- | :-------------------------------------------------------------------------------------------------------- |
+| TRACKING_PERMISSION_NOT_DETERMINED | 0     | See [`ATTrackingManagerAuthorizationStatusNotDetermined`][tracking-manager-status-not-determined-api-url] |
+| TRACKING_PERMISSION_RESTRICTED     | 1     | See [`ATTrackingManagerAuthorizationStatusRestricted`][tracking-manager-status-restricted-api-url]        |
+| TRACKING_PERMISSION_DENIED         | 2     | See [`ATTrackingManagerAuthorizationStatusDenied`][tracking-manager-status-denied-api-url]                |
+| TRACKING_PERMISSION_AUTHORIZED     | 3     | See [`ATTrackingManagerAuthorizationStatusAuthorized`][tracking-manager-status-authorized-api-url]        |
 
 ## Example
 
 ```js
 const idfaPlugin = cordova.plugins.idfa;
-const TrackingPermission = idfaPlugin.TrackingPermission;
 
 idfaPlugin.getInfo()
     .then(info => {
-        if (!info.isTrackingLimited) {
+        if (!info.trackingLimited) {
             return info.idfa || info.aaid;
-        } else if (info.trackingPermission === TrackingPermission.NotDetermined) {
+        } else if (info.trackingPermission === idfaPlugin.TRACKING_PERMISSION_NOT_DETERMINED) {
             return idfaPlugin.requestPermission().then(result => {
-                if (result !== TrackingPermission.Authorized) {
+                if (result !== idfaPlugin.TRACKING_PERMISSION_AUTHORIZED) {
                     return;
                 }
 
@@ -113,3 +115,7 @@ idfaPlugin.getInfo()
 [authorizationstatus-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus
 [requesttrackingauthorization-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorization
 [nsusertrackingusagedescription-api-url]: https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription
+[tracking-manager-status-not-determined-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusnotdetermined
+[tracking-manager-status-restricted-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusrestricted
+[tracking-manager-status-denied-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusdenied
+[tracking-manager-status-authorized-api-url]: https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusauthorized

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 
     $ cordova plugin add cordova-plugin-idfa
 
-Use variable `ANDROID_PLAY_ADID_VERSION` to override dependency version on Android.
+Use variable `ANDROID_PLAY_ADID_VERSION` to override dependency version on Android:
+
+    $ cordova plugin add cordova-plugin-idfa --variable ANDROID_PLAY_ADID_VERSION='16.+'
 
 ## API
 
@@ -32,24 +34,26 @@ The API is available on the `cordova.plugins.idfa` global object.
 
 Returns a `Promise<object>` with the following fields:
 
-- `limitAdTracking`: `boolean` - Whether usage of advertising id is allowed by user.
+- `isTrackingLimited`: `boolean` - Whether usage of advertising id is allowed by user.
 - `idfa`: `string` (_iOS only_) - Identifier for advertisers.
-- `trackingTransparencyStatus` (_iOS only_): `"NotAvailable"` | `"Authorized"` | `"Denied"` | `"Restricted"` | `"NotDetermined"` -
-   Tracking transparency status, available on iOS 14+ devices. On devices with iOS < 14 the value will always be
-   `"NotAvailable"`. For the meaning of other values see [the tracking transparency API docs][authorizationstatus-api-url].
+- `trackingPermission` (_iOS only_): [`TrackingPermission`](#trackingpermission)
+   Tracking permission status, available on iOS 14+ devices. On devices with iOS < 14 the value will
+   always be `null`.
 - `aaid`: `string` (_Android only_) - Android advertising ID.
 
-### requestTrackingAuthorization()
+### requestPermission()
 
 _(iOS only)_ A one-time request to authorize or deny access to app-related data that can be used for
 tracking the user or the device. See [Apple's API docs][requesttrackingauthorization-api-url]
 for more info on the dialog presented to the user. Available only for iOS 14+ devices.
 
-Returns a `Promise<string>` with the same values as [`getInfo()#trackingTransparencyStatus`](#getinfo) field.
-On devices with iOS < 14 the promise will always resolve with `"NotAvailable"`.
+Returns a `Promise<`[`TrackingPermission`](#trackingpermission)`>`. On devices
+with iOS < 14 the promise will always resolve with `null`.
 
-**Note:** You should make sure to set the `NSUserTrackingUsageDescription` key in your app's
-Information Property List file. You can do it with the following code in your Cordova project's `config.xml`:
+**Note:** You should make sure to set the
+[`NSUserTrackingUsageDescription`][nsusertrackingusagedescription-api-url] key in your app's
+Information Property List file, otherwise your app will crash when you use this API.
+You can do it with the following code in your Cordova project's `config.xml`:
 ```xml
 <platform name="ios">
     <edit-config target="NSUserTrackingUsageDescription" file="*-Info.plist" mode="merge">
@@ -57,20 +61,46 @@ Information Property List file. You can do it with the following code in your Co
     </edit-config>
 </platform>
 ```
-See [Apple's API docs][nsusertrackingusagedescription-api-url] for more info on this configuration key.
+
+### TrackingPermission
+
+An `object` containing all possible tracking permission values returned by [`getInfo()#trackingPermission`](#getinfo)
+and [`requestPermission()`](#requestPermission).
+
+For the meaning of the values see [the tracking transparency API docs][authorizationstatus-api-url]:
+
+- `Authorized`: `'Authorized'`
+- `Denied`: `'Denied'`
+- `Restricted`: `'Restricted'`
+- `NotDetermined`: `'NotDetermined'`
 
 ## Example
 
 ```js
-cordova.plugins.idfa.getInfo().then(function(info) {
-    if (!info.limitAdTracking) {
-        console.log(info.idfa || info.aaid);
-    }
-});
+const idfaPlugin = cordova.plugins.idfa;
+const TrackingPermission = idfaPlugin.TrackingPermission;
 
-cordova.plugins.idfa.requestTrackingAuthorization().then(function(status) {
-    console.log(status);
-});
+idfaPlugin.getInfo()
+    .then(info => {
+        if (!info.isTrackingLimited) {
+            return info.idfa || info.aaid;
+        } else if (info.trackingPermission === TrackingPermission.NotDetermined) {
+            return idfaPlugin.requestPermission().then(result => {
+                if (result !== TrackingPermission.Authorized) {
+                    return;
+                }
+
+                return idfaPlugin.getInfo().then(info => {
+                    return info.idfa || info.aaid;
+                });
+            });
+        }
+    })
+    .then(idfaOrAaid => {
+        if (idfaOrAaid) {
+            console.log(idfaOrAaid);
+        }
+    });
 ```
 
 [npm-url]: https://www.npmjs.com/package/cordova-plugin-idfa

--- a/src/android/IdfaPlugin.java
+++ b/src/android/IdfaPlugin.java
@@ -21,7 +21,7 @@ public class IdfaPlugin extends ReflectiveCordovaPlugin {
 
         JSONObject result = new JSONObject();
         result.put("aaid", info.getId());
-        result.put("limitAdTracking", info.isLimitAdTrackingEnabled());
+        result.put("isTrackingLimited", info.isLimitAdTrackingEnabled());
         callbackContext.success(result);
     }
 }

--- a/src/android/IdfaPlugin.java
+++ b/src/android/IdfaPlugin.java
@@ -21,7 +21,7 @@ public class IdfaPlugin extends ReflectiveCordovaPlugin {
 
         JSONObject result = new JSONObject();
         result.put("aaid", info.getId());
-        result.put("isTrackingLimited", info.isLimitAdTrackingEnabled());
+        result.put("trackingLimited", info.isLimitAdTrackingEnabled());
         callbackContext.success(result);
     }
 }

--- a/src/ios/IdfaPlugin.h
+++ b/src/ios/IdfaPlugin.h
@@ -4,4 +4,6 @@
 
 - (void)getInfo:(CDVInvokedUrlCommand*)command;
 
+- (void)requestTrackingAuthorization:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/IdfaPlugin.h
+++ b/src/ios/IdfaPlugin.h
@@ -4,6 +4,6 @@
 
 - (void)getInfo:(CDVInvokedUrlCommand*)command;
 
-- (void)requestTrackingAuthorization:(CDVInvokedUrlCommand*)command;
+- (void)requestPermission:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/IdfaPlugin.m
+++ b/src/ios/IdfaPlugin.m
@@ -38,7 +38,9 @@
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }];
         } else {
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+            CDVPluginResult* pluginResult = [CDVPluginResult
+                                             resultWithStatus:CDVCommandStatus_ERROR
+                                             messageAsString:@"requestPermission is supported only for iOS >= 14!"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
     }];

--- a/src/ios/IdfaPlugin.m
+++ b/src/ios/IdfaPlugin.m
@@ -8,26 +8,26 @@
     [self.commandDelegate runInBackground:^{
         NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
         BOOL enabled = [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled];
-        NSString *trackingTransparencyStatus = @"NotAvailable";
+        NSString *trackingPermission;
 
         if (@available(iOS 14, *)) {
             ATTrackingManagerAuthorizationStatus status = ATTrackingManager.trackingAuthorizationStatus;
             switch (status) {
                 case ATTrackingManagerAuthorizationStatusAuthorized:
-                    trackingTransparencyStatus = @"Authorized";
+                    trackingPermission = @"Authorized";
                     enabled = YES;
                     break;
 
                 case ATTrackingManagerAuthorizationStatusDenied:
-                    trackingTransparencyStatus = @"Denied";
+                    trackingPermission = @"Denied";
                     break;
 
                 case ATTrackingManagerAuthorizationStatusRestricted:
-                    trackingTransparencyStatus = @"Restricted";
+                    trackingPermission = @"Restricted";
                     break;
 
                 default:
-                    trackingTransparencyStatus = @"NotDetermined";
+                    trackingPermission = @"NotDetermined";
                     break;
             }
 
@@ -40,40 +40,40 @@
 
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:@{
             @"idfa": idfaString,
-            @"limitAdTracking": [NSNumber numberWithBool:!enabled],
-            @"trackingTransparencyStatus": trackingTransparencyStatus
+            @"isTrackingLimited": [NSNumber numberWithBool:!enabled],
+            @"trackingPermission": trackingPermission ?: [NSNull null]
         }];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
 
-- (void)requestTrackingAuthorization:(CDVInvokedUrlCommand *)command {
+- (void)requestPermission:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate runInBackground:^{
         if (@available(iOS 14, *)) {
             [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-                NSString *trackingTransparencyStatus;
+                NSString *trackingPermission;
                 switch (status) {
                     case ATTrackingManagerAuthorizationStatusAuthorized:
-                        trackingTransparencyStatus = @"Authorized";
+                        trackingPermission = @"Authorized";
                         break;
 
                     case ATTrackingManagerAuthorizationStatusDenied:
-                        trackingTransparencyStatus = @"Denied";
+                        trackingPermission = @"Denied";
                         break;
 
                     case ATTrackingManagerAuthorizationStatusRestricted:
-                        trackingTransparencyStatus = @"Restricted";
+                        trackingPermission = @"Restricted";
                         break;
 
                     default:
-                        trackingTransparencyStatus = @"NotDetermined";
+                        trackingPermission = @"NotDetermined";
                         break;
                 }
-                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:trackingTransparencyStatus];
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:trackingPermission];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }];
         } else {
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"NotAvailable"];
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
     }];

--- a/src/ios/IdfaPlugin.m
+++ b/src/ios/IdfaPlugin.m
@@ -47,4 +47,36 @@
     }];
 }
 
+- (void)requestTrackingAuthorization:(CDVInvokedUrlCommand *)command {
+    [self.commandDelegate runInBackground:^{
+        if (@available(iOS 14, *)) {
+            [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+                NSString *trackingTransparencyStatus;
+                switch (status) {
+                    case ATTrackingManagerAuthorizationStatusAuthorized:
+                        trackingTransparencyStatus = @"Authorized";
+                        break;
+
+                    case ATTrackingManagerAuthorizationStatusDenied:
+                        trackingTransparencyStatus = @"Denied";
+                        break;
+
+                    case ATTrackingManagerAuthorizationStatusRestricted:
+                        trackingTransparencyStatus = @"Restricted";
+                        break;
+
+                    default:
+                        trackingTransparencyStatus = @"NotDetermined";
+                        break;
+                }
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:trackingTransparencyStatus];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            }];
+        } else {
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"NotAvailable"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    }];
+}
+
 @end

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,10 @@
+type TrackingTransparencyStatus =
+    | "NotAvailable"
+    | "Authorized"
+    | "Denied"
+    | "Restricted"
+    | "NotDetermined";
+
 /**
  * The data retrieved by the Idfa plugin.
  */
@@ -18,12 +25,7 @@ interface IdfaData {
      * For the meaning of other values see
      * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
      */
-    trackingTransparencyStatus?:
-        | "NotAvailable"
-        | "Authorized"
-        | "Denied"
-        | "Restricted"
-        | "NotDetermined";
+    trackingTransparencyStatus?: TrackingTransparencyStatus;
 
     /**
      * Android advertising ID _(Android only)_.
@@ -47,6 +49,34 @@ interface IdfaPlugin {
      * });
      */
     getInfo(): Promise<IdfaData>;
+
+    /**
+     * _(iOS only)_ A one-time request to authorize or deny access to app-related data
+     * that can be used for tracking the user or the device. See
+     * [Apple's API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorization)
+     * for more info. Available only for iOS 14+ devices. On devices with iOS < 14 the
+     * returned promise will always resolve with `"NotAvailable"`.
+     *
+     * **Note:** You should make sure to set the `NSUserTrackingUsageDescription` key in your app's
+     * Information Property List file. See
+     * [Apple's API docs](https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription)
+     * for more info.
+     *
+     * @example
+     *
+     * // config.xml
+     * <platform name="ios">
+     *     <edit-config target="NSUserTrackingUsageDescription" file="*-Info.plist" mode="merge">
+     *         <string>My tracking usage description</string>
+     *     </edit-config>
+     * </platform>
+     *
+     * // index.ts
+     * cordova.plugins.idfa.requestTrackingAuthorization().then((status) => {
+     *     console.log(status);
+     * });
+     */
+    requestTrackingAuthorization(): Promise<TrackingTransparencyStatus>;
 }
 
 interface CordovaPlugins {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,4 @@
-type TrackingPermission =
-    | "Authorized"
-    | "Denied"
-    | "Restricted"
-    | "NotDetermined";
+type TrackingPermission = 0 | 1 | 2 | 3;
 
 /**
  * The data retrieved by the Idfa plugin.
@@ -11,7 +7,7 @@ interface IdfaData {
     /**
      * Whether usage of advertising id is allowed by user.
      */
-    isTrackingLimited: boolean;
+    trackingLimited: boolean;
 
     /**
      * Identifier for advertisers _(iOS only)_.
@@ -21,6 +17,9 @@ interface IdfaData {
     /**
      * Tracking permission status _(iOS only)_. Available only for iOS 14+ devices.
      * On devices with iOS < 14 the value will always be `null`.
+     *
+     * For the meaning of the values see
+     * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
      */
     trackingPermission?: TrackingPermission | null;
 
@@ -35,15 +34,21 @@ interface IdfaData {
  */
 interface IdfaPlugin {
     /**
-     * Possible tracking permission values. For the meaning of the values see
-     * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
+     * Tracking permission value for the ["not determined" status](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusnotdetermined).
      */
-    TrackingPermission: Readonly<{
-        Authorized: "Authorized";
-        Denied: "Denied";
-        Restricted: "Restricted";
-        NotDetermined: "NotDetermined";
-    }>;
+    readonly TRACKING_PERMISSION_NOT_DETERMINED: 0;
+    /**
+     * Tracking permission value for the ["restricted" status](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusrestricted).
+     */
+    readonly TRACKING_PERMISSION_RESTRICTED: 1;
+    /**
+     * Tracking permission value for the ["permission denied" status](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusdenied).
+     */
+    readonly TRACKING_PERMISSION_DENIED: 2;
+    /**
+     * Tracking permission value for the ["authorized" status](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus/attrackingmanagerauthorizationstatusauthorized).
+     */
+    readonly TRACKING_PERMISSION_AUTHORIZED: 3;
 
     /**
      * Retrieve the advertising id info for the current platform.
@@ -51,7 +56,7 @@ interface IdfaPlugin {
      * @example
      *
      * cordova.plugins.idfa.getInfo().then((info) => {
-     *     if (!info.isTrackingLimited) {
+     *     if (!info.trackingLimited) {
      *         console.log(info.idfa || info.aaid);
      *     }
      * });
@@ -62,13 +67,17 @@ interface IdfaPlugin {
      * _(iOS only)_ A one-time request to authorize or deny access to app-related data
      * that can be used for tracking the user or the device. See
      * [Apple's API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorization)
-     * for more info. Available only for iOS 14+ devices. On devices with iOS < 14 the
-     * returned promise will always resolve with `null`.
+     * for more info.
      *
      * **Note:** You should make sure to set the `NSUserTrackingUsageDescription` key in your app's
      * Information Property List file, otherwise your app will crash when you use this API. See
      * [Apple's API docs](https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription)
      * for more info.
+     *
+     * @returns A promise with the user's tracking permission choice. Available only for iOS 14+ devices.
+     * On devices with iOS < 14 the returned promise will always resolve with `null`.
+     * For the meaning of the returned values see
+     * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
      *
      * @example
      *
@@ -81,7 +90,7 @@ interface IdfaPlugin {
      *
      * // index.ts
      * cordova.plugins.idfa.requestPermission().then((status) => {
-     *     console.log(status);
+     *     console.log(status === cordova.plugins.idfa.TRACKING_PERMISSION_AUTHORIZED);
      * });
      */
     requestPermission(): Promise<TrackingPermission | null>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,4 @@
-type TrackingTransparencyStatus =
-    | "NotAvailable"
+type TrackingPermission =
     | "Authorized"
     | "Denied"
     | "Restricted"
@@ -12,7 +11,7 @@ interface IdfaData {
     /**
      * Whether usage of advertising id is allowed by user.
      */
-    limitAdTracking: boolean;
+    isTrackingLimited: boolean;
 
     /**
      * Identifier for advertisers _(iOS only)_.
@@ -20,12 +19,10 @@ interface IdfaData {
     idfa?: string;
 
     /**
-     * Tracking transparency status _(iOS only)_. Available only for iOS 14+ devices.
-     * On devices with iOS < 14 the value will always be `"NotAvailable"`.
-     * For the meaning of other values see
-     * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
+     * Tracking permission status _(iOS only)_. Available only for iOS 14+ devices.
+     * On devices with iOS < 14 the value will always be `null`.
      */
-    trackingTransparencyStatus?: TrackingTransparencyStatus;
+    trackingPermission?: TrackingPermission | null;
 
     /**
      * Android advertising ID _(Android only)_.
@@ -38,12 +35,23 @@ interface IdfaData {
  */
 interface IdfaPlugin {
     /**
+     * Possible tracking permission values. For the meaning of the values see
+     * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
+     */
+    TrackingPermission: Readonly<{
+        Authorized: "Authorized";
+        Denied: "Denied";
+        Restricted: "Restricted";
+        NotDetermined: "NotDetermined";
+    }>;
+
+    /**
      * Retrieve the advertising id info for the current platform.
      *
      * @example
      *
      * cordova.plugins.idfa.getInfo().then((info) => {
-     *     if (!info.limitAdTracking) {
+     *     if (!info.isTrackingLimited) {
      *         console.log(info.idfa || info.aaid);
      *     }
      * });
@@ -55,10 +63,10 @@ interface IdfaPlugin {
      * that can be used for tracking the user or the device. See
      * [Apple's API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorization)
      * for more info. Available only for iOS 14+ devices. On devices with iOS < 14 the
-     * returned promise will always resolve with `"NotAvailable"`.
+     * returned promise will always resolve with `null`.
      *
      * **Note:** You should make sure to set the `NSUserTrackingUsageDescription` key in your app's
-     * Information Property List file. See
+     * Information Property List file, otherwise your app will crash when you use this API. See
      * [Apple's API docs](https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription)
      * for more info.
      *
@@ -72,11 +80,11 @@ interface IdfaPlugin {
      * </platform>
      *
      * // index.ts
-     * cordova.plugins.idfa.requestTrackingAuthorization().then((status) => {
+     * cordova.plugins.idfa.requestPermission().then((status) => {
      *     console.log(status);
      * });
      */
-    requestTrackingAuthorization(): Promise<TrackingTransparencyStatus>;
+    requestPermission(): Promise<TrackingPermission | null>;
 }
 
 interface CordovaPlugins {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ interface IdfaPlugin {
      * for more info.
      *
      * @returns A promise with the user's tracking permission choice. Available only for iOS 14+ devices.
-     * On devices with iOS < 14 the returned promise will always resolve with `null`.
+     * On devices with iOS < 14 the returned promise will be rejected.
      * For the meaning of the returned values see
      * [the tracking transparency API docs](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanagerauthorizationstatus).
      *

--- a/www/Idfa.js
+++ b/www/Idfa.js
@@ -6,5 +6,11 @@ module.exports = {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "getInfo", []);
         });
+    },
+
+    requestTrackingAuthorization: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", []);
+        });
     }
 };

--- a/www/Idfa.js
+++ b/www/Idfa.js
@@ -2,12 +2,10 @@ var exec = require("cordova/exec");
 var PLUGIN_NAME = "Idfa";
 
 module.exports = {
-    TrackingPermission: Object.freeze({
-        Authorized: "Authorized",
-        Denied: "Denied",
-        Restricted: "Restricted",
-        NotDetermined: "NotDetermined",
-    }),
+    TRACKING_PERMISSION_NOT_DETERMINED: 0,
+    TRACKING_PERMISSION_RESTRICTED: 1,
+    TRACKING_PERMISSION_DENIED: 2,
+    TRACKING_PERMISSION_AUTHORIZED: 3,
 
     getInfo: function() {
         return new Promise(function(resolve, reject) {

--- a/www/Idfa.js
+++ b/www/Idfa.js
@@ -2,15 +2,22 @@ var exec = require("cordova/exec");
 var PLUGIN_NAME = "Idfa";
 
 module.exports = {
+    TrackingPermission: Object.freeze({
+        Authorized: "Authorized",
+        Denied: "Denied",
+        Restricted: "Restricted",
+        NotDetermined: "NotDetermined",
+    }),
+
     getInfo: function() {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "getInfo", []);
         });
     },
 
-    requestTrackingAuthorization: function() {
+    requestPermission: function() {
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", []);
+            exec(resolve, reject, PLUGIN_NAME, "requestPermission", []);
         });
     }
 };


### PR DESCRIPTION
Adds the [bespoke](https://github.com/chemerisuk/cordova-plugin-idfa/pull/5#issuecomment-705427700) `requestTrackingAuthorization()` API.

Fixes #7